### PR TITLE
Updates supporting release 1.0 of the WeatherKit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,31 @@ go get github.com/shawntoffel/go-weatherkit
 
 ## Usage
 
-Import the package into your project:
+### Import the package into your project:
 
 ```go
 import "github.com/shawntoffel/go-weatherkit"
 ```
 
-Create a new weatherkit client:
+### Create a new weatherkit client:
 
 ```go
-client := weatherkit.Client{}
-```
+// See Authentication documentation below.
+privateKeyBytes, _ := os.ReadFile("/path/to/AuthKey_ABCDE12345.p8")
 
-Build a request:
+client := weatherkit.NewCredentialedClient(weatherkit.Credentials{
+	KeyID:      "key ID",
+	TeamID:     "team ID",
+	ServiceID:  "service ID",
+	PrivateKey: privateKeyBytes,
+})
+```
+Locating your identifiers:
+* **Key ID (kid)**: An identifier associated with your private key. It can be found on the [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/authkeys/list) page under Keys. Click on the appropriate key to view the ID. 
+* **Team ID (tid)**: Found on the [account](https://developer.apple.com/account) page under Membership details.
+* **Service ID (sid)**: Found on the [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list/serviceId) page under Identifiers. Make sure "Services IDs" is selected from the dropdown. 
+
+### Build a request:
 
 ```go
 request := weatherkit.WeatherRequest{
@@ -45,18 +57,12 @@ request := weatherkit.WeatherRequest{
 }
 ```
 
-Get a response:
+### Get a response:
 ```go
 ctx := context.Background()
 
-// token is a JWT developer token. See the Authentication notes below.
-response, err := client.Weather(ctx, token, request)
+response, err := client.Weather(ctx, request)
 ```
-
-## Authentication
-A JWT developer `token` parameter is used to authenticate requests. See the documentation [here](https://developer.apple.com/documentation/weatherkitrestapi/request_authentication_for_weatherkit_rest_api) for details on WeatherKit API authentication.
-
-A separate project [go-appledev](https://github.com/shawntoffel/go-appledev) might be useful for generating short-lived developer tokens. It outputs a valid signed developer token using your private key, key ID, team ID, service ID, and a duration of your choice as inputs. It may be used as a library or CLI app. 
 
 ## Documentation
 
@@ -75,6 +81,7 @@ See Apple's documentation for Apple Weather and third-party attribution requirem
 - [Current weather](https://github.com/shawntoffel/go-weatherkit/tree/master/examples/current_weather/main.go)
 - [Hourly forecast](https://github.com/shawntoffel/go-weatherkit/tree/master/examples/hourly_forecast/main.go)
 - [Multiple data sets](https://github.com/shawntoffel/go-weatherkit/tree/master/examples/multiple_datasets/main.go)
+- [DIY Credentials](https://github.com/shawntoffel/go-weatherkit/tree/master/examples/diy_credentials/main.go)
 
 ## Troubleshooting
 Please use the GitHub [Discussions](https://github.com/shawntoffel/go-weatherkit/discussions) tab for questions regarding this client library. The Apple Developer forums are available for questions regarding the underlying API: https://developer.apple.com/forums/tags/weatherkit

--- a/attribution.go
+++ b/attribution.go
@@ -1,0 +1,25 @@
+package weatherkit
+
+// AttributionRequest requests attribution details.
+type AttributionRequest struct {
+	// (Required) The language tag to use for localizing responses.
+	Language string `json:"language,omitempty"`
+}
+
+func (o AttributionRequest) url() string {
+	return attribution(o.Language)
+}
+
+// AttributionResponse contains an official attribution branding.
+type AttributionResponse struct {
+	LogoDark1x   string `json:"logoDark@1x,omitempty"`
+	LogoDark2x   string `json:"logoDark@2x,omitempty"`
+	LogoDark3x   string `json:"logoDark@3x,omitempty"`
+	LogoLight1x  string `json:"logoLight@1x,omitempty"`
+	LogoLight2x  string `json:"logoLight@2x,omitempty"`
+	LogoLight3x  string `json:"logoLight@3x,omitempty"`
+	LogoSquare1x string `json:"logoSquare@1x,omitempty"`
+	LogoSquare2x string `json:"logoSquare@2x,omitempty"`
+	LogoSquare3x string `json:"logoSquare@3x,omitempty"`
+	ServiceName  string `json:"serviceName,omitempty"`
+}

--- a/attribution_test.go
+++ b/attribution_test.go
@@ -1,0 +1,18 @@
+package weatherkit
+
+import (
+	"testing"
+)
+
+func TestAttributionRequestFullUrlGeneration(t *testing.T) {
+	req := AttributionRequest{
+		Language: "en",
+	}
+
+	want := BaseUrl + "/attribution/en"
+	have := req.url()
+
+	if want != have {
+		t.Errorf("want: %s, have: %s", want, have)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -7,12 +7,159 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"sync"
+	"time"
 )
 
 // DefaultUserAgent to send along with requests.
 const DefaultUserAgent = "shawntoffel/go-weatherkit"
 
-// Client is a WeatherKit API client.
+// NewCredentialedClient creates a new client with creds.
+func NewCredentialedClient(credentials Credentials, opts ...CredentialedClientOption) *CredentialedClient {
+	cc := &CredentialedClient{
+		credentials: credentials,
+		options:     defaultcredentialedClientOptions(),
+	}
+
+	if opts == nil || len(opts) < 1 {
+		return cc
+	}
+
+	for _, opt := range opts {
+		opt.apply(cc.options)
+	}
+
+	return cc
+}
+
+// CredentialedClient is a WeatherKit API client.
+// Construct with NewCredentialedClient.
+type CredentialedClient struct {
+	options     *credentialedClientOptions
+	credentials Credentials
+	mu          sync.Mutex
+	token       string
+	exp         time.Time
+}
+
+func (c *CredentialedClient) getToken() (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.options == nil {
+		c.options = defaultcredentialedClientOptions()
+	}
+
+	if c.options.disableCache {
+		signed, _, err := c.credentials.SignedJWT(c.options.tokenDuration)
+		return signed, err
+	}
+
+	// Use a minute buffer to allow for req/resp time.
+	if len(c.token) > 0 && c.exp.After(time.Now().UTC().Add(time.Minute)) {
+		return c.token, nil
+	}
+
+	signed, exp, err := c.credentials.SignedJWT(c.options.tokenDuration)
+	if err != nil {
+		return "", err
+	}
+
+	c.token = signed
+	c.exp = exp
+
+	return c.token, nil
+}
+
+// Weather obtains weather data for the specified location.
+func (d *CredentialedClient) Weather(ctx context.Context, request WeatherRequest) (*WeatherResponse, error) {
+	token, err := d.getToken()
+	if err != nil {
+		return nil, err
+	}
+	return d.options.client.Weather(ctx, token, request)
+}
+
+// Availability determines the data sets available for the specified location.
+func (d *CredentialedClient) Availability(ctx context.Context, request AvailabilityRequest) (*AvailabilityResponse, error) {
+	token, err := d.getToken()
+	if err != nil {
+		return nil, err
+	}
+	return d.options.client.Availability(ctx, token, request)
+}
+
+// Alert receives information on an active weather alert.
+func (d *CredentialedClient) Alert(ctx context.Context, request WeatherAlertRequest) (*WeatherAlertResponse, error) {
+	token, err := d.getToken()
+	if err != nil {
+		return nil, err
+	}
+	return d.options.client.Alert(ctx, token, request)
+}
+
+// Attribution retrieves official attribution branding.
+func (d *CredentialedClient) Attribution(ctx context.Context, request AttributionRequest) (*AttributionResponse, error) {
+	return d.options.client.Attribution(ctx, request)
+}
+
+// CredentialedClientOption configures a CredentialedClient.
+type CredentialedClientOption interface {
+	apply(*credentialedClientOptions)
+}
+
+type credentialedClientOptions struct {
+	disableCache  bool
+	client        *Client
+	tokenDuration time.Duration
+}
+
+type funcOption struct {
+	f func(*credentialedClientOptions)
+}
+
+func (fo *funcOption) apply(o *credentialedClientOptions) {
+	fo.f(o)
+}
+
+func newFuncOption(f func(*credentialedClientOptions)) *funcOption {
+	return &funcOption{
+		f: f,
+	}
+}
+
+func defaultcredentialedClientOptions() *credentialedClientOptions {
+	return &credentialedClientOptions{
+		client:        &Client{},
+		tokenDuration: defaultTokenDuration,
+	}
+}
+
+// WithoutCache returns an Option which disables token caching.
+// A new JWT will be generated for each request.
+func WithoutCache() CredentialedClientOption {
+	return newFuncOption(func(o *credentialedClientOptions) {
+		o.disableCache = true
+	})
+}
+
+// WithClient returns an Option which configures a custom Client.
+func WithClient(client *Client) CredentialedClientOption {
+	return newFuncOption(func(o *credentialedClientOptions) {
+		o.client = client
+	})
+}
+
+// WithTokenDuration returns an Option which configures the expiration duration of the internally generated JWTs.
+// The default duration is 10 minutes.
+func WithTokenDuration(duration time.Duration) CredentialedClientOption {
+	return newFuncOption(func(o *credentialedClientOptions) {
+		o.tokenDuration = duration
+	})
+}
+
+// Client is a WeatherKit API client without Credentials.
+// Use NewCredentialedClient for automatic JWT handling.
 type Client struct {
 	HttpClient *http.Client
 
@@ -44,6 +191,13 @@ func (d *Client) Alert(ctx context.Context, token string, request WeatherAlertRe
 	return &response, err
 }
 
+// Attribution retrieves official attribution branding.
+func (d *Client) Attribution(ctx context.Context, request AttributionRequest) (*AttributionResponse, error) {
+	response := AttributionResponse{}
+	err := d.get(ctx, "", request, &response)
+	return &response, err
+}
+
 func (d *Client) get(ctx context.Context, token string, request urlBuilder, output interface{}) error {
 	if d.HttpClient == nil {
 		d.HttpClient = &http.Client{}
@@ -57,7 +211,10 @@ func (d *Client) get(ctx context.Context, token string, request urlBuilder, outp
 	req.Header.Add("User-Agent", d.userAgent())
 	req.Header.Add("Accept", "application/json; charset=utf-8")
 	req.Header.Add("Accept-Encoding", "gzip")
-	req.Header.Add("Authorization", "Bearer "+token)
+
+	if len(token) > 0 {
+		req.Header.Add("Authorization", "Bearer "+token)
+	}
 
 	response, err := d.HttpClient.Do(req)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -97,8 +97,44 @@ func TestWeatherAlertErrorResponse(t *testing.T) {
 	assertJsonEqual(t, expected, actual)
 }
 
-func weather(t *testing.T, filename string) {
+func TestAttributionResponse(t *testing.T) {
 	client := Client{}
+
+	server, expected, err := getMockServerWithFileData("testdata/attribution.json", http.StatusOK)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	defer server.Close()
+	BaseUrl = server.URL
+
+	response, err := client.Attribution(context.TODO(), AttributionRequest{
+		Language: "en",
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	actual, err := json.Marshal(response)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	assertJsonEqual(t, expected, actual)
+}
+
+func weather(t *testing.T, filename string) {
+	pk, err := createPrivateKeyPEM()
+	if err != nil {
+		t.Error(err)
+	}
+
+	client := NewCredentialedClient(Credentials{
+		KeyID:      "key",
+		TeamID:     "team",
+		ServiceID:  "service",
+		PrivateKey: pk,
+	})
 
 	server, expected, err := getMockServerWithFileData(filename, http.StatusOK)
 	if err != nil {
@@ -108,7 +144,7 @@ func weather(t *testing.T, filename string) {
 	defer server.Close()
 	BaseUrl = server.URL
 
-	response, err := client.Weather(context.TODO(), "", WeatherRequest{})
+	response, err := client.Weather(context.TODO(), WeatherRequest{})
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -122,7 +158,17 @@ func weather(t *testing.T, filename string) {
 }
 
 func availability(t *testing.T, filename string) {
-	client := Client{}
+	pk, err := createPrivateKeyPEM()
+	if err != nil {
+		t.Error(err)
+	}
+
+	client := NewCredentialedClient(Credentials{
+		KeyID:      "key",
+		TeamID:     "team",
+		ServiceID:  "service",
+		PrivateKey: pk,
+	})
 
 	server, expected, err := getMockServerWithFileData(filename, http.StatusOK)
 	if err != nil {
@@ -132,7 +178,7 @@ func availability(t *testing.T, filename string) {
 	defer server.Close()
 	BaseUrl = server.URL
 
-	response, err := client.Availability(context.TODO(), "", AvailabilityRequest{})
+	response, err := client.Availability(context.TODO(), AvailabilityRequest{})
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/credentials.go
+++ b/credentials.go
@@ -1,0 +1,107 @@
+package weatherkit
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+const defaultTokenDuration time.Duration = time.Minute * 10
+
+// Credentials holds information required to authenticate against the weatherkit API.
+type Credentials struct {
+	// PrivateKey is your PEM encoded private key.
+	PrivateKey []byte
+
+	// KeyID is the Key identifier from your developer account.
+	KeyID string
+
+	// TeamID is the Team ID from your developer account.
+	TeamID string
+
+	// ServiceID is the Service ID from your developer account.
+	ServiceID string
+}
+
+// SignedJWT generates a valid JWT signed with your PEM private key.
+// Returns the string JWT along with its expiration time.
+func (c *Credentials) SignedJWT(validFor time.Duration) (string, time.Time, error) {
+	token, exp, err := c.create(validFor)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	signed, err := c.sign(token)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	return signed, exp, nil
+}
+
+func (c *Credentials) create(validFor time.Duration) (*jwt.Token, time.Time, error) {
+	err := c.validate(validFor)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	now := time.Now().UTC()
+	exp := now.Add(validFor)
+
+	return &jwt.Token{
+		Header: map[string]interface{}{
+			"alg": jwt.SigningMethodES256.Alg(),
+			"kid": c.KeyID,
+			"id":  c.TeamID + "." + c.ServiceID,
+		},
+		Claims: jwt.MapClaims{
+			"iss": c.TeamID,
+			"sub": c.ServiceID,
+			"iat": now.Unix(),
+			"exp": exp.Unix(),
+		},
+		Method: jwt.SigningMethodES256,
+	}, exp, nil
+}
+
+func (c *Credentials) sign(token *jwt.Token) (string, error) {
+	privateKey, err := jwt.ParseECPrivateKeyFromPEM(c.PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse private key. %s", err)
+	}
+
+	signedJwt, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to create signed JWT. %s", err)
+	}
+
+	return signedJwt, nil
+}
+
+func (c *Credentials) validate(validFor time.Duration) error {
+	messages := []string{}
+
+	if len(c.KeyID) < 1 {
+		messages = append(messages, "key identifier may not be empty")
+	}
+
+	if len(c.TeamID) < 1 {
+		messages = append(messages, "team ID may not be empty")
+	}
+
+	if len(c.ServiceID) < 1 {
+		messages = append(messages, "service ID may not be empty")
+	}
+
+	if validFor <= 0 {
+		messages = append(messages, "token expiration must be in the future (duration must be greater than 0)")
+	}
+
+	if len(messages) > 0 {
+		return fmt.Errorf("validation failed: %s", strings.Join(messages, ", "))
+	}
+
+	return nil
+}

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -1,0 +1,86 @@
+package weatherkit
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+func TestGenerateSignedJwt(t *testing.T) {
+	pk, err := createPrivateKeyPEM()
+	if err != nil {
+		t.Error(err)
+	}
+
+	g := Credentials{
+		PrivateKey: pk,
+		KeyID:      "key",
+		TeamID:     "team",
+		ServiceID:  "service",
+	}
+
+	signed, _, err := g.SignedJWT(time.Minute * 10)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(signed)
+
+	claims := jwt.MapClaims{}
+
+	parsed, _ := jwt.ParseWithClaims(signed, &claims, func(token *jwt.Token) (interface{}, error) {
+		return nil, nil
+	})
+
+	alg := parsed.Header["alg"]
+	expectedAlg := "ES256"
+	if alg != "ES256" {
+		t.Errorf("expected alg: %s, got: %s", expectedAlg, alg)
+	}
+
+	iss := claims["iss"]
+	if iss != g.TeamID {
+		t.Errorf("expected team ID : %s, got: %s", g.TeamID, iss)
+	}
+
+	sub := claims["sub"]
+	if sub != g.ServiceID {
+		t.Errorf("expected service ID : %s, got: %s", g.ServiceID, sub)
+	}
+
+	kid := parsed.Header["kid"]
+	if kid != g.KeyID {
+		t.Errorf("expected kid: %s, got: %s", g.KeyID, kid)
+	}
+
+	id := parsed.Header["id"]
+	expectedID := g.TeamID + "." + g.ServiceID
+	if id != g.TeamID+"."+g.ServiceID {
+		t.Errorf("expected team ID: %s, got: %s", expectedID, id)
+	}
+}
+
+func createPrivateKeyPEM() ([]byte, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	marshalled, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	block := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: marshalled,
+	}
+
+	return pem.EncodeToMemory(block), nil
+}

--- a/endpoints.go
+++ b/endpoints.go
@@ -20,6 +20,10 @@ func weatherAlertEndpoint(lang string, id string) string {
 	return BaseUrl + "/weatherAlert/" + fmt.Sprintf("%s/%s", lang, id)
 }
 
+func attribution(lang string) string {
+	return BaseUrl + "/attribution/" + lang
+}
+
 func encodeUrlParameters(values url.Values) string {
 	queryString := values.Encode()
 

--- a/examples/availability/main.go
+++ b/examples/availability/main.go
@@ -3,18 +3,29 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/shawntoffel/go-weatherkit"
 )
 
 // print data set availability in new york
 func main() {
-	client := weatherkit.Client{}
+	privateKeyBytes, err := os.ReadFile("/path/to/AuthKey_ABCDE12345.p8")
+	if err != nil {
+		fmt.Println("failed to load private key", err.Error())
+		return
+	}
 
-	token := "my token"
+	client := weatherkit.NewCredentialedClient(weatherkit.Credentials{
+		KeyID:      "key ID",
+		TeamID:     "team ID",
+		ServiceID:  "service ID",
+		PrivateKey: privateKeyBytes,
+	})
+
 	ctx := context.Background()
 
-	availability, err := client.Availability(ctx, token, weatherkit.AvailabilityRequest{
+	availability, err := client.Availability(ctx, weatherkit.AvailabilityRequest{
 		Latitude:  38.960,
 		Longitude: -104.506,
 	})

--- a/examples/current_weather/main.go
+++ b/examples/current_weather/main.go
@@ -3,15 +3,26 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/shawntoffel/go-weatherkit"
 )
 
 // print the current temp in new york
 func main() {
-	client := weatherkit.Client{}
+	privateKeyBytes, err := os.ReadFile("/path/to/AuthKey_ABCDE12345.p8")
+	if err != nil {
+		fmt.Println("failed to load private key", err.Error())
+		return
+	}
 
-	token := "my token"
+	client := weatherkit.NewCredentialedClient(weatherkit.Credentials{
+		KeyID:      "key ID",
+		TeamID:     "team ID",
+		ServiceID:  "service ID",
+		PrivateKey: privateKeyBytes,
+	})
+
 	ctx := context.Background()
 
 	request := weatherkit.WeatherRequest{
@@ -23,7 +34,7 @@ func main() {
 		},
 	}
 
-	weather, err := client.Weather(ctx, token, request)
+	weather, err := client.Weather(ctx, request)
 	if err != nil {
 		fmt.Println("error", err.Error())
 		return

--- a/examples/diy_credentials/main.go
+++ b/examples/diy_credentials/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shawntoffel/go-weatherkit"
+)
+
+// Demonstrates how to use the plain Client if you generate JWT developer tokens yourself.
+func main() {
+	client := weatherkit.Client{}
+
+	request := weatherkit.WeatherRequest{
+		Latitude:  38.960,
+		Longitude: -104.506,
+		Language:  "en",
+		DataSets: weatherkit.DataSets{
+			weatherkit.DataSetCurrentWeather,
+		},
+	}
+
+	ctx := context.Background()
+	token := "your JWT developer token generated elsewhere"
+
+	weather, err := client.Weather(ctx, token, request)
+	if err != nil {
+		fmt.Println("error", err.Error())
+		return
+	}
+
+	fmt.Println(weather.CurrentWeather.Temperature)
+}

--- a/examples/hourly_forecast/main.go
+++ b/examples/hourly_forecast/main.go
@@ -3,15 +3,26 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/shawntoffel/go-weatherkit"
 )
 
 // print hour 0 temp in new york
 func main() {
-	client := weatherkit.Client{}
+	privateKeyBytes, err := os.ReadFile("/path/to/AuthKey_ABCDE12345.p8")
+	if err != nil {
+		fmt.Println("failed to load private key", err.Error())
+		return
+	}
 
-	token := "my token"
+	client := weatherkit.NewCredentialedClient(weatherkit.Credentials{
+		KeyID:      "key ID",
+		TeamID:     "team ID",
+		ServiceID:  "service ID",
+		PrivateKey: privateKeyBytes,
+	})
+
 	ctx := context.Background()
 
 	request := weatherkit.WeatherRequest{
@@ -23,7 +34,7 @@ func main() {
 		},
 	}
 
-	weather, err := client.Weather(ctx, token, request)
+	weather, err := client.Weather(ctx, request)
 	if err != nil {
 		fmt.Println("error", err.Error())
 		return

--- a/examples/multiple_datasets/main.go
+++ b/examples/multiple_datasets/main.go
@@ -3,15 +3,26 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/shawntoffel/go-weatherkit"
 )
 
 // print current, day 0 temp max, and hour 0 temp.
 func main() {
-	client := weatherkit.Client{}
+	privateKeyBytes, err := os.ReadFile("/path/to/AuthKey_ABCDE12345.p8")
+	if err != nil {
+		fmt.Println("failed to load private key", err.Error())
+		return
+	}
 
-	token := "my token"
+	client := weatherkit.NewCredentialedClient(weatherkit.Credentials{
+		KeyID:      "key ID",
+		TeamID:     "team ID",
+		ServiceID:  "service ID",
+		PrivateKey: privateKeyBytes,
+	})
+
 	ctx := context.Background()
 
 	request := weatherkit.WeatherRequest{
@@ -25,7 +36,7 @@ func main() {
 		},
 	}
 
-	weather, err := client.Weather(ctx, token, request)
+	weather, err := client.Weather(ctx, request)
 	if err != nil {
 		fmt.Println("error", err.Error())
 		return

--- a/examples/weather_alert/main.go
+++ b/examples/weather_alert/main.go
@@ -3,15 +3,26 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/shawntoffel/go-weatherkit"
 )
 
 // print event text for an alert id
 func main() {
-	client := weatherkit.Client{}
+	privateKeyBytes, err := os.ReadFile("/path/to/AuthKey_ABCDE12345.p8")
+	if err != nil {
+		fmt.Println("failed to load private key", err.Error())
+		return
+	}
 
-	token := "my token"
+	client := weatherkit.NewCredentialedClient(weatherkit.Credentials{
+		KeyID:      "key ID",
+		TeamID:     "team ID",
+		ServiceID:  "service ID",
+		PrivateKey: privateKeyBytes,
+	})
+
 	ctx := context.Background()
 
 	request := weatherkit.WeatherAlertRequest{
@@ -19,7 +30,7 @@ func main() {
 		Language: "en",
 	}
 
-	response, err := client.Alert(ctx, token, request)
+	response, err := client.Alert(ctx, request)
 	if err != nil {
 		fmt.Println("error", err.Error())
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/shawntoffel/go-weatherkit
 
 go 1.18
+
+require github.com/golang-jwt/jwt/v4 v4.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=

--- a/testdata/attribution.json
+++ b/testdata/attribution.json
@@ -1,0 +1,12 @@
+{
+    "logoDark@3x": "/assets/branding/en/Apple_Weather_wht_en_3X_090122.png",
+    "logoLight@1x": "/assets/branding/en/Apple_Weather_blk_en_1X_090122.png",
+    "logoDark@2x": "/assets/branding/en/Apple_Weather_wht_en_2X_090122.png",
+    "logoDark@1x": "/assets/branding/en/Apple_Weather_wht_en_1X_090122.png",
+    "logoLight@2x": "/assets/branding/en/Apple_Weather_blk_en_2X_090122.png",
+    "logoLight@3x": "/assets/branding/en/Apple_Weather_blk_en_3X_090122.png",
+    "logoSquare@2x": "/assets/branding/square-mark@2x.png",
+    "serviceName": "Apple Weather",
+    "logoSquare@1x": "/assets/branding/square-mark.png",
+    "logoSquare@3x": "/assets/branding/square-mark@3x.png"
+}


### PR DESCRIPTION
* Added a new `CredentialedClient` & constructor method with JWT handling based on [go-appledev](https://github.com/shawntoffel/go-appledev). Automatically generates and renews the JWT developer token using your keyId, teamId, serviceId, and private key. The plain `Client` can still be used if you want to handle JWTs yourself. 
* Added support for the `Attribution` endpoint. 